### PR TITLE
Avoid warnings from using deprecated torch APIs and torch arguments

### DIFF
--- a/core/igev_stereo.py
+++ b/core/igev_stereo.py
@@ -9,15 +9,31 @@ import time
 
 
 try:
-    autocast = torch.cuda.amp.autocast
-except:
+    # Use the new AMP API to avoid FutureWarning from `torch.cuda.amp.autocast`.
+    _autocast = torch.amp.autocast
+
     class autocast:
-        def __init__(self, enabled):
-            pass
+        def __init__(self, enabled=True, dtype=None):
+            self._ctx = _autocast("cuda", enabled=enabled, dtype=dtype)
+
         def __enter__(self):
-            pass
+            return self._ctx.__enter__()
+
         def __exit__(self, *args):
-            pass
+            return self._ctx.__exit__(*args)
+except Exception:
+    try:
+        autocast = torch.cuda.amp.autocast
+    except Exception:
+        class autocast:
+            def __init__(self, enabled=True, dtype=None):
+                pass
+
+            def __enter__(self):
+                pass
+
+            def __exit__(self, *args):
+                pass
 
 class hourglass(nn.Module):
     def __init__(self, in_channels):

--- a/core/update.py
+++ b/core/update.py
@@ -113,8 +113,13 @@ def interp(x, dest):
     original_dtype = x.dtype
     x_fp32 = x.float()
     interp_args = {'mode': 'bilinear', 'align_corners': True}
-    with torch.cuda.amp.autocast(enabled=False):
-        output_fp32 = F.interpolate(x_fp32, dest.shape[2:], **interp_args)
+    # Use the newer AMP API; this silences FutureWarning from `torch.cuda.amp.autocast`.
+    try:
+        with torch.amp.autocast("cuda", enabled=False):
+            output_fp32 = F.interpolate(x_fp32, dest.shape[2:], **interp_args)
+    except Exception:
+        with torch.cuda.amp.autocast(enabled=False):
+            output_fp32 = F.interpolate(x_fp32, dest.shape[2:], **interp_args)
     if original_dtype != torch.float32:
         output = output_fp32.to(original_dtype)
     else:

--- a/core_rt/rt_igev_stereo.py
+++ b/core_rt/rt_igev_stereo.py
@@ -8,15 +8,31 @@ from core_rt.submodule import *
 
 
 try:
-    autocast = torch.cuda.amp.autocast
-except:
+    # Use the new AMP API to avoid FutureWarning from `torch.cuda.amp.autocast`.
+    _autocast = torch.amp.autocast
+
     class autocast:
-        def __init__(self, enabled):
-            pass
+        def __init__(self, enabled=True, dtype=None):
+            self._ctx = _autocast("cuda", enabled=enabled, dtype=dtype)
+
         def __enter__(self):
-            pass
+            return self._ctx.__enter__()
+
         def __exit__(self, *args):
-            pass
+            return self._ctx.__exit__(*args)
+except Exception:
+    try:
+        autocast = torch.cuda.amp.autocast
+    except Exception:
+        class autocast:
+            def __init__(self, enabled=True, dtype=None):
+                pass
+
+            def __enter__(self):
+                pass
+
+            def __exit__(self, *args):
+                pass
 
 class hourglass(nn.Module):
     def __init__(self, in_channels):

--- a/core_rt/update.py
+++ b/core_rt/update.py
@@ -103,8 +103,13 @@ def interp(x, dest):
     original_dtype = x.dtype
     x_fp32 = x.float()
     interp_args = {'mode': 'bilinear', 'align_corners': True}
-    with torch.cuda.amp.autocast(enabled=False):
-        output_fp32 = F.interpolate(x_fp32, dest.shape[2:], **interp_args)
+    # Use the newer AMP API; this silences FutureWarning from `torch.cuda.amp.autocast`.
+    try:
+        with torch.amp.autocast("cuda", enabled=False):
+            output_fp32 = F.interpolate(x_fp32, dest.shape[2:], **interp_args)
+    except Exception:
+        with torch.cuda.amp.autocast(enabled=False):
+            output_fp32 = F.interpolate(x_fp32, dest.shape[2:], **interp_args)
     if original_dtype != torch.float32:
         output = output_fp32.to(original_dtype)
     else:

--- a/evaluate_stereo.py
+++ b/evaluate_stereo.py
@@ -48,8 +48,9 @@ def validate_eth3d(model, iters=32, mixed_prec=False):
         occ_mask = Image.open(GT_file.replace('disp0GT.pfm', 'mask0nocc.png'))
 
         occ_mask = np.ascontiguousarray(occ_mask).flatten()
-
-        val = (valid_gt.flatten() >= 0.5) & (occ_mask == 255)
+        # Ensure the indexing mask is a boolean tensor (PyTorch warns on uint8 masks).
+        occ_mask_t = torch.as_tensor(occ_mask == 255, device=valid_gt.device, dtype=torch.bool)
+        val = (valid_gt.flatten() >= 0.5) & occ_mask_t
         # val = (valid_gt.flatten() >= 0.5)
         out = (epe_flattened > 1.0)
         image_out = out[val].float().mean().item()
@@ -99,6 +100,7 @@ def validate_kitti(model, iters=32, mixed_prec=False):
 
         epe_flattened = epe.flatten()
         val = (valid_gt.flatten() >= 0.5) & (flow_gt.abs().flatten() < 192)
+        val = val.to(torch.bool)
         # val = valid_gt.flatten() >= 0.5
 
         out = (epe_flattened > 3.0)

--- a/evaluate_stereo.py
+++ b/evaluate_stereo.py
@@ -245,7 +245,12 @@ if __name__ == '__main__':
     if args.restore_ckpt is not None:
         assert args.restore_ckpt.endswith(".pth")
         logging.info("Loading checkpoint...")
-        checkpoint = torch.load(args.restore_ckpt)
+        # checkpoints here are expected to be `state_dict` only (see train scripts)
+        try:
+            checkpoint = torch.load(args.restore_ckpt, weights_only=True)
+        except TypeError:
+            # Fall-back to older PyTorch versions that may not have the `weights_only` argument.
+            checkpoint = torch.load(args.restore_ckpt)
         model.load_state_dict(checkpoint, strict=True)
         logging.info(f"Done loading checkpoint")
 

--- a/evaluate_stereo_rt.py
+++ b/evaluate_stereo_rt.py
@@ -48,8 +48,9 @@ def validate_eth3d(model, iters=32, mixed_prec=False):
         occ_mask = Image.open(GT_file.replace('disp0GT.pfm', 'mask0nocc.png'))
 
         occ_mask = np.ascontiguousarray(occ_mask).flatten()
-
-        val = (valid_gt.flatten() >= 0.5) & (occ_mask == 255)
+        # Ensure the indexing mask is boolean
+        occ_mask_t = torch.as_tensor(occ_mask == 255, device=valid_gt.device, dtype=torch.bool)
+        val = (valid_gt.flatten() >= 0.5) & occ_mask_t
         # val = (valid_gt.flatten() >= 0.5)
         out = (epe_flattened > 1.0)
         image_out = out[val].float().mean().item()
@@ -99,6 +100,7 @@ def validate_kitti(model, iters=32, mixed_prec=False):
 
         epe_flattened = epe.flatten()
         val = (valid_gt.flatten() >= 0.5) & (flow_gt.abs().flatten() < 192)
+        val = val.to(torch.bool)
         # val = valid_gt.flatten() >= 0.5
 
         out = (epe_flattened > 3.0)
@@ -147,6 +149,7 @@ def validate_sceneflow(model, iters=32, mixed_prec=False):
 
         epe = epe.flatten()
         val = (valid_gt.flatten() >= 0.5) & (disp_gt.abs().flatten() < 192)
+        val = val.to(torch.bool)
         if(np.isnan(epe[val].mean().item())):
             continue
 
@@ -191,7 +194,8 @@ def validate_middlebury(model, iters=32, split='MiddEval3', resolution='F', mixe
 
         occ_mask = Image.open(imageL_file.replace('im0.png', 'mask0nocc.png')).convert('L')
         occ_mask = np.ascontiguousarray(occ_mask, dtype=np.float32).flatten()
-        val = (valid_gt.reshape(-1) >= 0.5) & (flow_gt[0].reshape(-1) < 192) & (occ_mask==255)
+        occ_mask_t = torch.as_tensor(occ_mask == 255, device=valid_gt.device, dtype=torch.bool)
+        val = (valid_gt.reshape(-1) >= 0.5) & (flow_gt[0].reshape(-1) < 192) & occ_mask_t
         out = (epe_flattened > 2.0)
         image_out = out[val].float().mean().item()
         image_epe = epe_flattened[val].mean().item()

--- a/evaluate_stereo_rt.py
+++ b/evaluate_stereo_rt.py
@@ -241,7 +241,12 @@ if __name__ == '__main__':
     if args.restore_ckpt is not None:
         assert args.restore_ckpt.endswith(".pth")
         logging.info("Loading checkpoint...")
-        checkpoint = torch.load(args.restore_ckpt)
+        # checkpoints here are expected to be `state_dict` only (see train scripts).
+        try:
+            checkpoint = torch.load(args.restore_ckpt, weights_only=True)
+        except TypeError:
+            # Fall-back to older PyTorch versions that may not have the `weights_only` argument.
+            checkpoint = torch.load(args.restore_ckpt)
         model.load_state_dict(checkpoint, strict=True)
         logging.info(f"Done loading checkpoint")
 


### PR DESCRIPTION
A few warning messages are gone by using the newer torch APIs with safe fall-back treatments in case the older version does not support:

1. Use `torch.amp.autocast('cuda', args...)` rather than `torch.cuda.amp.autocast(args...)` since the latter is deprecated.
2. `evaluate_stereo.py` computes `val` and then indexes tensors, _e.g._, `out[val]` and `epe_flattened[val]`. In your run, `val` ended up as a `torch.uint8` mask. It is fixed by forcing `val` to be a boolean tensor, _i.e._, `torch.bool` masks.
3. The training code saves checkpoints as `model.state_dict()`, _i.e._, weights-only, so it is preferable to load the pretrained model with `weights_only=True` argument.